### PR TITLE
Change exported image format and fileName

### DIFF
--- a/userInterface/Components/ImagesDataCollection.js
+++ b/userInterface/Components/ImagesDataCollection.js
@@ -2,12 +2,14 @@ const OverlayCanvas = require("./Canvas/OverlayCanvas.js")
 const ImageCanvas = require("./Canvas/ImageCanvas.js")
 
 class ImageSaveData {
-    constructor(receivedImageFile, receivedFileName) {
+    constructor(receivedImageFile, receivedImageName, receivedFileName, receivedImageType) {
         //this.textBoxArray = []
         this.listOfTextBoxes = new Map()
         this.imageSizeArray = []
         this.imageFile = receivedImageFile
+        this.imageName = receivedImageName
         this.fileName = receivedFileName
+        this.imageType = receivedImageType
     }
 
     checkIfTextboxExists(textboxID) {
@@ -169,11 +171,11 @@ class ImagesDataCollection {
             let imageObj = new Image();
             let URLObj = window.URL || window.webkitURL;
             let imageFile = URLObj.createObjectURL(image);
-            let imageName = image.name.split('.')[0];
+            let imageFileName = image.name.split('.')[0];
 
             console.log("this.listOfImagesData", this.listOfImagesData)
             imageObj.src = imageFile
-            this.listOfImagesData.push(new ImageSaveData(imageFile, imageName))
+            this.listOfImagesData.push(new ImageSaveData(imageFile, image.name, imageFileName, image.type))
 
             imageObj.onload = () => {
                 this.listOfImagesData[i].saveImageSize(imageObj.width, imageObj.height)
@@ -194,7 +196,7 @@ class ImagesDataCollection {
         let imageObj = new Image();
         let URLObj = window.URL || window.webkitURL;
         let imageFile = URLObj.createObjectURL(imageData);
-        this.listOfImagesData.push(new ImageSaveData(imageFile, "noName"))
+        this.listOfImagesData.push(new ImageSaveData(imageFile, "noName.jpg", "image/jpeg"))
         imageObj.src = imageFile
         imageObj.onload =() => {
             this.listOfImagesData[0].saveImageSize(imageObj.width, imageObj.height)

--- a/userInterface/Components/exportTextRemovedButton.js
+++ b/userInterface/Components/exportTextRemovedButton.js
@@ -29,10 +29,12 @@ class exportTextRemovedButton {
 
     async downloadImage() {
         let a = document.createElement('a');
-        let imageFile = await this.exportImage(ImagesDataCollection.getCurrentSaveData().imageFile)
+        let imageData = ImagesDataCollection.getCurrentSaveData();
+        let imageFile = await this.exportImage(imageData.imageFile)
         //let image = imageFile.replace("image/png", "image/octet-stream");
+
         a.setAttribute("href", imageFile);
-        a.setAttribute('download', `fileName.png`);
+        a.setAttribute('download', imageData.imageName);
         a.click()
     }
 
@@ -51,9 +53,11 @@ class exportTextRemovedButton {
 
         temporaryContext.drawImage(imageObj, 0, 0, imageObj.width, imageObj.height)
 
-        this.fillRegionsWithWhite(temporaryContext, ImagesDataCollection.getCurrentSaveData().getListOfTextBoxes())
+        let imageData = ImagesDataCollection.getCurrentSaveData();
 
-        return temporaryCanvas.toDataURL("image/png");
+        this.fillRegionsWithWhite(temporaryContext, imageData.getListOfTextBoxes())
+
+        return temporaryCanvas.toDataURL(imageData.imageType);
     }
 
     fillRegionsWithWhite(thisCanvas, outlinesList) {


### PR DESCRIPTION
### Summary

- Preserve image type and image name for `Export Text Removed`. 
- Previously it always saved it in a `png` format. The `png` format is heavier in size than `jpg`.
- The size difference for an example `jpg` image was: `PNG: 4.4MB` vs `JPG: 1.8MB`.
- Change so it exports with the original fileName rather than the current `fileName`.

|          Original Image           |
| :------------------------: |
| <img src="https://user-images.githubusercontent.com/2285726/124395263-c0906780-dd0b-11eb-867d-910481f61fc7.png" width="100%" > |

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://user-images.githubusercontent.com/2285726/124395280-d3a33780-dd0b-11eb-8ab8-4deee8bca73e.png" width="100%" > | <img src="https://user-images.githubusercontent.com/2285726/124395242-a9ea1080-dd0b-11eb-904c-c6e77485c19d.png" width="100%" > |

## Testing

- Tested the `Export Text Removed` for both `jpg` and `png` images 
