### PR TITLE
Fit image in the browser window

### DIFF
--- a/userInterface/Components/Canvas/Canvas.js
+++ b/userInterface/Components/Canvas/Canvas.js
@@ -4,6 +4,17 @@ class Canvas {
         this.mainContext = receivedContext
     }
 
+    resizeCanvasFromImage(imageObj) {
+        let reservedSpacePercentage = 0.25 // control panel + right side
+        let availableWidth = window.outerWidth - (window.outerWidth * reservedSpacePercentage)
+
+        let imageRatio = imageObj.height / imageObj.width;
+        let width = Math.min(availableWidth, imageObj.width)
+        let height = width * imageRatio;
+
+        this.resizeCanvas(width, height)
+    }
+
     resizeCanvas(width, height) {
         this.mainCanvas.width = width
         this.mainCanvas.height = height

--- a/userInterface/Components/Canvas/OverlayCanvas.js
+++ b/userInterface/Components/Canvas/OverlayCanvas.js
@@ -12,7 +12,7 @@ class OverlayCanvas extends Canvas {
         let imageObj = new Image();
         imageObj.src = imageFile;
         await imageObj.decode()
-        this.resizeCanvas(imageObj.width, imageObj.height)
+        this.resizeCanvasFromImage(imageObj)
         this.mainContext.drawImage(imageObj, 0, 0, this.mainCanvas.width, this.mainCanvas.height);
     }
 

--- a/userInterface/Components/ImagesDataCollection.js
+++ b/userInterface/Components/ImagesDataCollection.js
@@ -211,18 +211,19 @@ class ImagesDataCollection {
     }
 
     reset() {
-        this.currentImageData = 0 
+        this.currentImageData = 0
         this.listOfImagesData = []
         this.resetID()
     }
-    
+
 
     displayImage(imageFile) {
         let imageObj = new Image();
         imageObj.src = imageFile;
+
         imageObj.onload = () => {
-            ImageCanvas.resizeCanvas(imageObj.width, imageObj.height)
-            OverlayCanvas.resizeCanvas(imageObj.width, imageObj.height)
+            ImageCanvas.resizeCanvasFromImage(imageObj)
+            OverlayCanvas.resizeCanvasFromImage(imageObj)
             ImageCanvas.mainContext.drawImage(imageObj, 0, 0, ImageCanvas.mainCanvas.width, ImageCanvas.mainCanvas.height);
         };
     }

--- a/userInterface/Components/Load Image/LoadFileImageToCanvas.js
+++ b/userInterface/Components/Load Image/LoadFileImageToCanvas.js
@@ -29,8 +29,8 @@ class LoadFileImageToCanvas {
             imageObj.src = imageFile
             //imageObj.src = URLObj.createObjectURL(imageFile);
             imageObj.onload =() => {
-                this.imageCanvas.resizeCanvas(imageObj.width, imageObj.height)
-                this.overlayCanvas.resizeCanvas(imageObj.width, imageObj.height)
+                this.imageCanvas.resizeCanvasFromImage(imageObj)
+                this.overlayCanvas.resizeCanvasFromImage(imageObj)
 
                 this.imageCanvas.mainContext.drawImage(imageObj, 0, 0, this.imageCanvas.mainCanvas.width, this.imageCanvas.mainCanvas.height);
             };

--- a/userInterface/Components/Load Image/PasteImageToCanvas.js
+++ b/userInterface/Components/Load Image/PasteImageToCanvas.js
@@ -27,8 +27,8 @@ class PasteImageToCanvas {
         imageObj.onload = () => {
             ModeSwitch.createModeActivate()
 
-            this.imageCanvas.resizeCanvas(imageObj.width, imageObj.height)
-            this.overlayCanvas.resizeCanvas(imageObj.width, imageObj.height)
+            this.imageCanvas.resizeCanvasFromImage(imageObj)
+            this.overlayCanvas.resizeCanvasFromImage(imageObj)
 
             this.imageCanvas.mainContext.drawImage(imageObj, 0, 0, this.imageCanvas.mainCanvas.width, this.imageCanvas.mainCanvas.height);
         };

--- a/userInterface/Components/LoadDataFolder.js
+++ b/userInterface/Components/LoadDataFolder.js
@@ -48,8 +48,8 @@ class LoadDataFolder {
         let URLObj = window.URL || window.webkitURL;
         imageObj.src = URLObj.createObjectURL(imageFile);
         imageObj.onload =() => {
-            this.imageCanvas.resizeCanvas(imageObj.width, imageObj.height)
-            this.overlayCanvas.resizeCanvas(imageObj.width, imageObj.height)
+            this.imageCanvas.resizeCanvasFromImage(imageObj)
+            this.overlayCanvas.resizeCanvasFromImage(imageObj)
             this.imageCanvas.mainContext.drawImage(imageObj, 0, 0, this.imageCanvas.mainCanvas.width, this.imageCanvas.mainCanvas.height);
         };
     }

--- a/userInterface/Components/exportTextRemovedButton.js
+++ b/userInterface/Components/exportTextRemovedButton.js
@@ -51,17 +51,19 @@ class exportTextRemovedButton {
 
         temporaryContext.drawImage(imageObj, 0, 0, imageObj.width, imageObj.height)
 
-        this.fillRegionsWithWhite(temporaryContext, ImagesDataCollection.getCurrentSaveData().getListOfTextBoxes())
+        let diffRatio = imageObj.width / ImageCanvas.mainCanvas.width
+
+        this.fillRegionsWithWhite(temporaryContext, diffRatio, ImagesDataCollection.getCurrentSaveData().getListOfTextBoxes())
 
         return temporaryCanvas.toDataURL("image/png");
     }
 
-    fillRegionsWithWhite(thisCanvas, outlinesList) {
+    fillRegionsWithWhite(thisCanvas, diffRatio, outlinesList) {
         outlinesList.forEach(outline => {
-            let x = outline[1]
-            let y = outline[2]
-            let width = outline[3]
-            let height = outline[4]
+            let x = parseInt(outline[1] * diffRatio)
+            let y = parseInt(outline[2] * diffRatio)
+            let width = parseInt(outline[3] * diffRatio)
+            let height = parseInt(outline[4] * diffRatio)
 
             this.fillWithWhiteColor(thisCanvas, x, y, width, height)
         });


### PR DESCRIPTION
## Summary

- Fit image in the browser window. The image with a big size does not fit the window and requires a horizontal scroll which loses the visibility of the control panel and it is slightly harder to navigate.
- Hopefully, this change will make it easier to edit bigger images.

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://user-images.githubusercontent.com/2285726/124401723-bbdfa980-dd33-11eb-933e-bcab0e30a00f.png" width="100%" > | <img src="https://user-images.githubusercontent.com/2285726/124401616-001e7a00-dd33-11eb-894e-84b61237b769.png" width="100%" > |

## Alternative Approach

- Could be a toggle to switch between original size and fit size. 

## Testing

Tested different modes and the image export.

